### PR TITLE
Add an explicit return statement

### DIFF
--- a/src/webos/browser/webos_browser_main_parts.cc
+++ b/src/webos/browser/webos_browser_main_parts.cc
@@ -127,6 +127,10 @@ int WebOSBrowserMainParts::PreCreateThreads() {
 
   for (size_t i = 0; i < webos_extra_parts_.size(); ++i)
     webos_extra_parts_[i]->PreCreateThreads();
+
+  // It should return the error code (or 0 if no error).
+  // See 'content::BrowserMainParts'.
+  return 0;
 }
 
 void WebOSBrowserMainParts::PostDestroyThreads() {


### PR DESCRIPTION
It adds an explicit return statement at
'WebOSBrowserMainParts::PreCreateThreads' as following definition
from content::BrowserMainParts. Otherwise, Chromium process
silently exits on AGL FF branch.