### PR TITLE
Set surface ID with process id if it is 0

### DIFF
--- a/src/ozone/wayland/shell/ivi_shell_surface.cc
+++ b/src/ozone/wayland/shell/ivi_shell_surface.cc
@@ -31,6 +31,11 @@ void IVIShellSurface::InitializeShellSurface(WaylandWindow* window,
   DCHECK(display);
   WaylandShell* shell = WaylandDisplay::GetInstance()->GetShell();
   DCHECK(shell && shell->GetIVIShell());
+
+  // The window_manager on AGL handles surface_id 0 as an invalid id.
+  if (surface_id == 0)
+    surface_id = static_cast<int>(getpid());
+
   ivi_surface_ = ivi_application_surface_create(shell->GetIVIShell(),
                                                 surface_id, GetWLSurface());
 


### PR DESCRIPTION
It sets surface ID with process ID if it has 0 as Window Manager
handles surface ID 0 as an invalid ID.

[SPEC-1889] Chromium is initially hidden when launched.
https://jira.automotivelinux.org/browse/SPEC-1889