### PR TITLE
[agl][ozone] Fix touch drag cancellation

### DIFF
--- a/src/ozone/ui/desktop_aura/webos_drag_drop_client_wayland.h
+++ b/src/ozone/ui/desktop_aura/webos_drag_drop_client_wayland.h
@@ -151,6 +151,8 @@ class VIEWS_EXPORT WebosDragDropClientWayland
   // See comment in OnGestureEvent() on why we need this.
   std::unique_ptr<ui::GestureEvent> pending_long_tap_;
 
+  bool scroll_gesture_drag_in_progress_;
+
   base::WeakPtrFactory<WebosDragDropClientWayland> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(WebosDragDropClientWayland);


### PR DESCRIPTION
In some cases StartDragAndDrop gets called but scroll gesture is never
detected before touch is already released. This creates situation where
drag is started but never finished because ET_GESTURE_SCROLL_END is never
generated. This happens when long press is detected and thus drag is
started but touch move/release immediately after that is too quick/fast to
detect scroll gesture.

[SPEC-2000] Add Drag and Drop support to WAM